### PR TITLE
Added dashes (-) to allowed topics

### DIFF
--- a/ntfy-daemon/src/models.rs
+++ b/ntfy-daemon/src/models.rs
@@ -18,7 +18,7 @@ fn emoji_map() -> &'static HashMap<String, String> {
 }
 
 pub fn validate_topic(topic: &str) -> Result<&str, Error> {
-    let re = Regex::new(r"^\w+$").unwrap();
+    let re = Regex::new(r"^[\w\-]+$").unwrap();
     if re.is_match(topic) {
         Ok(topic)
     } else {


### PR DESCRIPTION
Added the dash (-) to the regex in the topic validator, because the original ntfy enpoint and clients also support it.
Fixing #10.