### PR TITLE
Update clear message input on success

### DIFF
--- a/src/widgets/window.rs
+++ b/src/widgets/window.rs
@@ -221,8 +221,10 @@ impl NotifyWindow {
                     ..models::Message::default()
                 });
 
+            let e = entry.clone();
             entry.error_boundary().spawn(async move {
                 p.await?;
+                e.set_text("");
                 Ok(())
             });
         };


### PR DESCRIPTION
Clear the message input text when the message has been successfully sent.
Fixing #15.