### PR TITLE
Fix ending tag typo in com.ranfdev.Notify.metainfo.xml.in

### DIFF
--- a/data/resources/com.ranfdev.Notify.metainfo.xml.in.in
+++ b/data/resources/com.ranfdev.Notify.metainfo.xml.in.in
@@ -11,7 +11,7 @@
     <p>A desktop client for ntfy.</p>
     <ul>
     <li>Receive and send notifications with ntfy.sh or a self hosted ntfy server</li>
-    <li>View past notifications<li>
+    <li>View past notifications</li>
     <li>Runs automatically at startup and receives notifications in the background</li>
     </ul>
     <p>ntfy allows you to send notifications to your phone or desktop via scripts from any computer and/or using a REST API.</p>


### PR DESCRIPTION
On Arch, the build fails due to an improperly closed tag in this metainfo file.