### PR TITLE
Fixed issue with build process in Arch (AUR)

### DIFF
--- a/data/resources/com.ranfdev.Notify.metainfo.xml.in.in
+++ b/data/resources/com.ranfdev.Notify.metainfo.xml.in.in
@@ -43,6 +43,7 @@
   <releases>
     <release version="0.1.6" date="2024-11-24">
       <description>
+        <p>Lorem ipsum</p>
         <ul>
           <li>Fixed issue handling custom local certificates with https</li>
           <li>Updated GNOME sdk</li>
@@ -51,6 +52,7 @@
     </release>
     <release version="0.1.5" date="2024-01-03">
       <description>
+        <p>Lorem ipsum</p>
         <ul>
           <li>Fixed about window crashing</li>
         </ul>
@@ -58,6 +60,7 @@
     </release>
     <release version="0.1.4" date="2023-11-27">
       <description>
+        <p>Lorem ipsum</p>
         <ul>
           <li>Various bugfixes</li>
         </ul>
@@ -65,6 +68,7 @@
     </release>
     <release version="0.1.3" date="2023-11-16">
       <description>
+        <p>Lorem ipsum</p>
         <ul>
           <li>Support for basic authentication with custom accounts</li>
           <li>Custom server field is now prefilled when appropriate</li>
@@ -73,6 +77,7 @@
     </release>
     <release version="0.1.2" date="2023-11-07">
       <description>
+        <p>Lorem ipsum</p>
         <ul>
           <li>Introduced dialog to write advanced messages</li>
           <li>Automatic download of attached images</li>


### PR DESCRIPTION
Like described [here](https://aur.archlinux.org/packages/notify-git#comment-1056316) the build process on Arch from the AUR fails with the following error message:

```
==================================== 3/3 =====================================
test:         notify:validate-appdata
start time:   17:59:40
duration:     0.02s
result:       exit status 1
command:      MALLOC_PERTURB_=136 MSAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1 MESON_TEST_ITERATION=1 ASAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1 UBSAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1 /usr/bin/appstream-util validate --nonet /home/username/notify-git/src/build/data/resources/com.ranfdev.Notify.metainfo.xml
----------------------------------- stdout -----------------------------------
/home/username/notify-git/src/build/data/resources/com.ranfdev.Notify.metainfo.xml: FAILED:
• style-invalid         : <ul> cannot start a description [(null)]
• style-invalid         : Not enough <p> tags for a good description [0/1]
----------------------------------- stderr -----------------------------------
Validation of files failed
==============================================================================
```

As I don't know why there has to be a `<p>` instead of the `<ul>` after `<description>` I just added a "fake paragraph" with Lorem ipsum text. Helps to fix the build errors. Feel free to change the content if necessary.